### PR TITLE
remove duplicate bundle reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,5 @@
 </head>
 <body>
   <div id="app"></div>
-  <script type="text/javascript" src="bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
this line was creating an extra bundle reference in dist. the bundle line is already inserted by webpack into the dist folder, resulting in double the app (double requests, double everything. oops.)

should be merged in asap.